### PR TITLE
Date/404 page

### DIFF
--- a/#.gitignore#
+++ b/#.gitignore#
@@ -1,0 +1,2 @@
+.DS_Store tmp/ log/ db/test.sqlite3 db/development.sqlite3 *.swp *.swo
+coverage/

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -15,7 +15,7 @@ $(".after_schools.new").ready(function() {
 });
 
 $(".children.new").ready(function() {
-   $('.datepick').datepicker({ });
+   $('.datepick').datepicker({ changeYear: true, yearRange: "c-120:c+0", maxDate: "+0d" });
    $("#date").datepicker( "setDate" , new Date() );
 });
 

--- a/app/assets/javascripts/errors.js
+++ b/app/assets/javascripts/errors.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/errors.css.scss
+++ b/app/assets/stylesheets/errors.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the errors controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,12 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |exception|
-    flash[:error] = "You are not authorized to take this action."
-    redirect_to home_path
+    if current_user 
+      flash[:error] = "You are not authorized to take this action."
+      redirect_to home_path
+    else
+      render :file => "#{Rails.root}/public/404.html", :status => 404
+    end
   end
 
   private

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+class ErrorsController < ApplicationController
+  def error_404
+  	render :file => "#{Rails.root}/public/404.html", :status => 404
+  end
+
+  def error_500
+  end
+end

--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -54,6 +54,6 @@ class InstructorsController < ApplicationController
 		end
 
 		def instructor_params
-			params.require(:instructor).permit(:first_name, :last_name, :instructor_ids => [], user_attributes: [:id, :username, :password, :password_confirmation, :role])
+			params.require(:instructor).permit(:first_name, :last_name, :location_ids => [], user_attributes: [:id, :username, :password, :password_confirmation, :role])
 		end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -46,6 +46,6 @@ class LocationsController < ApplicationController
     end
 
     def location_params
-      params.require(:location).permit(:name, :address_line_one, :address_line_two, :city, :state, :zip, :phone, :instructor_ids => [])
+      params.require(:location).permit(:name, :address_line_one, :address_line_two, :city, :state, :zip, :phone)
     end
 end

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,2 @@
+module ErrorsHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -44,7 +44,7 @@ class Ability
         can :read, Instructor do |instructor|
             user_location = user.instructor.locations.map(&:id)
             instructor_location = instructor.locations.map(&:id)
-            (user_location & guardian_location).any?            
+            (user_location & instructor_location).any?            
         end
 
         can :update, Instructor do |instructor|

--- a/app/views/children/_guardian_form.html.erb
+++ b/app/views/children/_guardian_form.html.erb
@@ -22,8 +22,12 @@
 				        	</div></br></br>
 						    <div class="row">
 								<div class="col-lg-6 col-md-6 col-sm-12">  
-									<%= f.label :date_of_birth %></br>
-									<%= f.date_select(:date_of_birth, :start_year => 1900) %>
+									<div class="col-lg-6 col-md-6 col-sm-12">
+									  <%= f.label :date_of_birth, 'Date of Birth', :for => 'date_of_birth' %>
+					              	  <%= f.text_field :date_of_birth, :id=> 'date_of_birth', :class => 'datepick' %>
+								      <%#= f.label :date_of_birth %></br>
+									  <%#= f.date_select(:date_of_birth, :start_year => 1900) %>
+									</div>
 								</div>
 	        					<div class="col-lg-6 col-md-6 col-sm-12">
 									<p>

--- a/app/views/errors/error_404.html.erb
+++ b/app/views/errors/error_404.html.erb
@@ -1,0 +1,2 @@
+<h1>Errors#error_404</h1>
+<p>Find me in app/views/errors/error_404.html.erb</p>

--- a/app/views/errors/error_500.html.erb
+++ b/app/views/errors/error_500.html.erb
@@ -1,0 +1,2 @@
+<h1>Errors#error_500</h1>
+<p>Find me in app/views/errors/error_500.html.erb</p>

--- a/app/views/instructors/_form.html.erb
+++ b/app/views/instructors/_form.html.erb
@@ -36,6 +36,10 @@
 			<% end %>
 			<button class="" type="submit" name="action">Submit
 			</button>
+			<p>
+				<%= f.label :location_ids %>
+				<%= f.select :location_ids, options_for_select(Location.all.map{|l| [l.name, [l.id]]}) %>
+			</p>
 		<% end %>
 	  </div>
     </div>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -32,12 +32,5 @@
     <%= f.label :phone %><br>
     <%= f.text_field :phone %>
 
-    <h6> Assign Instructor to This Location </h6>
-    <% for instructor in @instructor %>
-      <%= check_box_tag "location[instructor_ids][]", instructor.id, @location.instructors.include?(instructor), {id: instructor.id} %>
-        <label for="<%= instructor.id %>"><%= instructor.proper_name %></label>
-        <br />
-    <% end  %>
-
     <%= f.submit %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,6 @@ HCEF::Application.routes.draw do
   get 'login' => 'sessions#new', :as => :login
   get 'logout' => 'sessions#destroy', :as => :logout
 
-  #redirect unmatched routes to 404.html
+  match '*post' => "errors#error_404", via: [:post, :get] 
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,5 @@ HCEF::Application.routes.draw do
   get 'signup' => 'users#new', :as => :signup
   get 'login' => 'sessions#new', :as => :login
   get 'logout' => 'sessions#destroy', :as => :logout
- 
-end
+
+  #redirect unmatched routes to 404.html

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ErrorsControllerTest < ActionController::TestCase
+  test "should get error_404" do
+    get :error_404
+    assert_response :success
+  end
+
+  test "should get error_500" do
+    get :error_500
+    assert_response :success
+  end
+
+end

--- a/test/helpers/errors_helper_test.rb
+++ b/test/helpers/errors_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class ErrorsHelperTest < ActionView::TestCase
+end


### PR DESCRIPTION
This pull changed two things:

1. Datepicker for Children/Guardian are changed so that it is consistent with other datepickers in the application. There is a dropdown menu for selecting the years, which resolves our original concern of the jquery datepicker for birthdays.

2. When user enters wrong address, 404.html page renders instead of no route matches page.
In addition:
When Instructor manually types in a link or clicks on things that he should not be able to do, it will render the error message as well as taking them back to /home
When unsigned user manually types in a link (trying to access different pages), it will render 404.html instead of giving them the 'You are not allowed to take this action' error.

This change is purely for security reasons, as we do not want regular users figuring out the structure of the database without logging in.